### PR TITLE
Precondition the velocity smoothing for the term that actually dominates

### DIFF
--- a/docs/research/OPEN.md
+++ b/docs/research/OPEN.md
@@ -113,6 +113,18 @@ each `eps` -- or for a small set of `eps` values, since
 The shifted-Jacobi kind exists but its lazy Laplacian-diagonal builder
 converts to numpy at trace time, so it cannot be used inside the jitted step
 as is.
+*Partially addressed 2026-09-02 (PR #19, issue #18):* the sibling **velocity
+smoothing** solve has the same symptom for the same reason and was measured
+rather than assumed. `eps * lambda_max(M^-1 L_hodge)` is 91.5 at `(8,16,8)`
+and 360.3 at `(12,24,12)`, not the ~0.26 the code claimed, so that solve is
+Laplacian-dominated too and refining makes it more so. Preconditioning the
+upper block with the LAPLACIAN atom as `(1/eps) P_L` instead of the MASS atom
+takes it from 2130/8493 iterations to 1655/3636 and the whole relaxation step
+from 13.02 s to 8.05 s on a v5e. That is a `laplacian` kind on the existing
+atoms, not the separable atom proposed here: growth per refinement improves
+from 4.0x to 2.2x but is still not flat, the crossover where the MASS atom
+would be right sits at `eps ~ 1e-4`, and the resistive solve above spans both
+sides of it. The separable atom remains the fix.
 *Detail:* `docs/source/concepts/relaxation.md` §2.
 
 ### 3.10 RESOLVED 2026-08-26: the iota = 1 core at (8,16,8) is a mesh artefact

--- a/mrx/operators.py
+++ b/mrx/operators.py
@@ -173,10 +173,25 @@ def _materialize_default_scalar_hodge_preconditioner(
 def _coerce_diffusion_preconditioner_spec(
         seq, operators: SequenceOperators, *, k: int, preconditioner):
     if preconditioner is None or preconditioner == 'auto':
-        # M + eps L is MASS-DOMINATED in the regime this solve is used in
-        # (the relaxation's velocity smoothing: eps * lambda_max(M^-1 L) ~ 0.26
-        # at ns=(8,16,8)), so the production MASS preconditioner is the right
-        # object.
+        # 'auto' is the MASS atom, which is right while M + eps L is
+        # mass-dominated. That is the resistive step's regime (eps = dt*eta),
+        # not the velocity smoothing's.
+        #
+        # This comment used to claim eps * lambda_max(M^-1 L) ~ 0.26 at
+        # ns=(8,16,8) and to conclude the mass atom was right everywhere.
+        # Power iteration says otherwise, by two and a half orders of
+        # magnitude, and the value is not resolution-flat either:
+        #
+        #   ns           eps        lambda_max(M^-1 L_hodge)   eps*lambda_max
+        #   (8,16,8)     1.00e-03   9.15e+04                    91.5
+        #   (12,24,12)   4.44e-04   8.11e+05                   360.3
+        #
+        # lambda_max grows ~8.9x between those while eps only falls 2.25x, so
+        # refining moves FURTHER from mass dominance rather than staying put.
+        # At the velocity smoothing's eps the LAPLACIAN atom is the right
+        # object and is what TimeStepper.smooth_velocity asks for; measured
+        # crossover is near eps = 1e-4 at ns=(8,16,8). See
+        # test/test_diffusion_preconditioner.py, which pins both sides of it.
         del seq, operators, k
         return default_mass_preconditioner()
     if isinstance(preconditioner, MassPreconditionerSpec):
@@ -1191,7 +1206,7 @@ def _build_diffusion_preconditioner_apply(
     # out: what this branch wants is "whatever the production mass
     # preconditioner currently is", and saying that literally is rename-proof.
     production_kind = default_mass_preconditioner().kind
-    valid_kinds = ('none', 'jacobi', production_kind)
+    valid_kinds = ('none', 'jacobi', 'laplacian', production_kind)
     if spec.kind not in valid_kinds:
         raise ValueError(
             "preconditioner kind must be one of "
@@ -1200,6 +1215,25 @@ def _build_diffusion_preconditioner_apply(
         if not allow_none:
             raise ValueError("this preconditioner slot does not allow kind='none'")
         return lambda x: x
+    if spec.kind == 'laplacian':
+        # (1/eps) P_L, for when eps L dominates M rather than the other way
+        # round. Measured on li383 k=2 against the mass atom, MINRES iterations
+        # to sqrt_eps, lower is better:
+        #
+        #   eps       mass    (1/eps) P_L      ns=(8,16,8)
+        #   1e-06      498          3682
+        #   1e-04      750          2919
+        #   1e-03     2130          1655       <- the smoothing eps here
+        #   1e-02     5774           950
+        #
+        #   ns=(12,24,12), eps=4.44e-04:  8493  vs  3636
+        #
+        # Note the scaling as well as the level: mass goes 2130 -> 8493 across
+        # those two resolutions (4.0x) where this goes 1655 -> 3636 (2.2x).
+        # Below the crossover it is much worse, which is why it is a kind the
+        # caller selects and not the 'auto' default.
+        return lambda x: (1.0 / eps) * apply_laplacian_preconditioner(
+            seq, operators, x, k, dirichlet=dirichlet)
     if spec.kind == 'jacobi':
         # The shifted diagonal 1 / (diag(M) + eps diag(L)): valid for every eps.
         mass_diaginv = _mass_diaginv(seq, operators, k, dirichlet)
@@ -1636,12 +1670,20 @@ def apply_inverse_mass_plus_eps_laplace_matrix(seq, operators: SequenceOperators
         preconditioner=preconditioner,
         allow_none=True,
     )
+    # The two blocks are not the same kind of operator, so one kind string
+    # cannot serve both. The upper block is M_k + eps L_k and takes whatever
+    # the caller asked for; the lower block is -eps M_{k-1}, a plain mass
+    # matrix, which is why kinds that only make sense against a Laplacian are
+    # replaced here rather than forwarded into a slot that would reject them.
+    lower_preconditioner = (
+        default_mass_preconditioner() if preconditioner == 'laplacian'
+        else preconditioner)
     lower_preconditioner_apply = _build_mass_preconditioner_apply(
         seq,
         operators,
         k=k - 1,
         dirichlet=dirichlet,
-        preconditioner=preconditioner,
+        preconditioner=lower_preconditioner,
         allow_none=True,
     )
 

--- a/mrx/relaxation.py
+++ b/mrx/relaxation.py
@@ -395,6 +395,14 @@ class TimeStepper(eqx.Module):
             0 (the default) leaves the direction as it is.
         velocity_smoothing_scale: Length scale of the smoothing,
             the ``mu`` in ``(M_2 + mu L_2)^-1 M_2``.
+        velocity_smoothing_preconditioner: Preconditioner kind for that
+            solve. ``'laplacian'``, the default, is ``(1/mu) P_L``: at this
+            ``mu`` the operator is Laplacian-dominated
+            (``mu * lambda_max(M^-1 L)`` measures 91.5 at ``ns=(8,16,8)`` and
+            360.3 at ``(12,24,12)``), so preconditioning the mass term alone
+            costs 1.3x the iterations at the first and 2.3x at the second.
+            ``'auto'`` restores the mass atom, which is the better choice
+            below the crossover near ``mu = 1e-4``.
         descent_method: GRADIENT or LBFGS (see :class:`DescentMethod`).
         dt_mode: FIXED or ANALYTIC_LINESEARCH.
         cfl: Cap on the step: ``dt = min(dt_star, cfl / cfl_max)`` with
@@ -423,6 +431,7 @@ class TimeStepper(eqx.Module):
     seq: DeRhamSequence
     velocity_smoothing_order: int = 0
     velocity_smoothing_scale: float = 0.0
+    velocity_smoothing_preconditioner: str = 'laplacian'
     descent_method: DescentMethod = DescentMethod.LBFGS
     dt_mode: TimeStepChoice = TimeStepChoice.ANALYTIC_LINESEARCH
     cfl: float = 0.5
@@ -535,7 +544,8 @@ class TimeStepper(eqx.Module):
         for _ in range(self.velocity_smoothing_order):
             rhs = self.seq.apply_mass_matrix(u, 2, True)
             u = self.seq.apply_inverse_mass_plus_eps_laplace_matrix(
-                rhs, 2, self.velocity_smoothing_scale, dirichlet=True, guess=u)
+                rhs, 2, self.velocity_smoothing_scale, dirichlet=True, guess=u,
+                preconditioner=self.velocity_smoothing_preconditioner)
         return u
 
     def update_field(self, state: State, field_name: Literal['B_n', 'B_nplus1', 'v', 'p_v', 'H', 'JxH', 'E', 's_history', 'y_history', 'F_prev', 'MF_prev', 'Ms_history', 'My_history', 'A', 'dt', 'dt_star', 'cfl_max', 'eta', 'resistive_info', 'resistive_delta', 'resistive_count', 'resistive_time', 'F_norm', 'v_norm', 'lbfgs_sy'], value) -> State:  # noqa: E501

--- a/test/test_diffusion_preconditioner.py
+++ b/test/test_diffusion_preconditioner.py
@@ -1,0 +1,137 @@
+"""Pin the diffusion solve's preconditioner choice to measured iteration counts.
+
+Nothing anywhere pinned the iteration count of ``M_k + eps L_k``, which is why
+a comment claiming ``eps * lambda_max(M^-1 L) ~ 0.26`` -- wrong by two and a
+half orders of magnitude -- justified the mass atom for years without anyone
+noticing that the velocity-smoothing solve had become 75% of a relaxation step.
+
+These tests are deliberately about *which preconditioner wins where*, not about
+an absolute count: the absolute number moves with geometry, tolerance and
+dtype, and a test that pins it would be rewritten rather than believed. What
+must not drift is the ordering, and the fact that the ordering reverses at a
+crossover in ``eps``.
+
+The reference numbers below are li383 at ``ns=(8,16,8)``, ``p=3``, float64,
+``tol = sqrt_eps``:
+
+    eps       mass    laplacian
+    1e-06      498         3682
+    1e-04      750         2919
+    1e-03     2130         1655
+    1e-02     5774          950
+"""
+import os
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import mrx
+from mrx.operators import (apply_inverse_mass_plus_eps_laplace_matrix,
+                           apply_mass_matrix)
+
+# The solve is O(10^3) iterations at the smoothing eps, so one sequence is
+# built for the whole module rather than per test.
+NS = (8, 16, 8)
+P = 3
+K = 2
+GEOMETRY = "data/wout_li383_low_res_reference.nc"
+
+pytestmark = pytest.mark.skipif(
+    not os.path.isfile(GEOMETRY), reason=f"{GEOMETRY} is absent")
+
+
+@pytest.fixture(scope="module")
+def seq_ops():
+    """li383 at (8,16,8) p=3 with the preconditioner atoms on the bundle."""
+    from mrx.geometry import build_sequence
+    from mrx.nullspace import compute_nullspaces
+    seq, _ = build_sequence(GEOMETRY, NS, P)
+    ops = seq.build_preconditioners()
+    seq.set_operators(compute_nullspaces(seq, ops))
+    return seq, seq.operators
+
+
+@pytest.fixture(scope="module")
+def rhs(seq_ops):
+    """``M_2 u`` for a fixed pseudo-random ``u``, the shape smooth_velocity uses."""
+    seq, _ = seq_ops
+    rng = np.random.default_rng(1)
+    u = jnp.asarray(rng.standard_normal(seq.n(K, True)), dtype=mrx.DTYPE)
+    return apply_mass_matrix(seq, u, K, dirichlet=True)
+
+
+def solve_iters(seq, ops, b, eps, kind, maxiter=20000):
+    """Solve ``(M + eps L) x = b`` with one preconditioner kind.
+
+    Returns ``(iterations, converged)``. ``info`` is the SIGNED iteration
+    count -- negative means converged -- which this file reads correctly
+    because reading it as "0 if converged" is a documented past bug in
+    mrx/solvers.py.
+    """
+    _, info = apply_inverse_mass_plus_eps_laplace_matrix(
+        seq, ops, b, K, eps, dirichlet=True, preconditioner=kind,
+        maxiter=maxiter, return_info=True)
+    return abs(int(info)), int(info) <= 0
+
+
+@pytest.mark.parametrize("eps", [1e-3, 1e-2])
+def test_laplacian_kind_wins_above_the_crossover(seq_ops, rhs, eps):
+    """At the velocity-smoothing eps, ``(1/eps) P_L`` beats the mass atom.
+
+    ``eps = 1e-3`` is exactly ``0.064/n_r^2`` at ``n_r = 8``, i.e. what
+    TimeStepper uses, so this is the production configuration and not a
+    contrived one.
+    """
+    seq, ops = seq_ops
+    mass_iters, mass_ok = solve_iters(seq, ops, rhs, eps, 'auto')
+    lap_iters, lap_ok = solve_iters(seq, ops, rhs, eps, 'laplacian')
+    assert mass_ok and lap_ok, (
+        f"both kinds must converge at eps={eps:g} "
+        f"(mass {mass_iters}, laplacian {lap_iters})")
+    assert lap_iters < mass_iters, (
+        f"at eps={eps:g} the laplacian kind took {lap_iters} iterations and "
+        f"the mass atom {mass_iters}; the laplacian kind is the default for "
+        "velocity smoothing precisely because it should win here")
+
+
+@pytest.mark.parametrize("eps", [1e-6, 1e-4])
+def test_mass_kind_wins_below_the_crossover(seq_ops, rhs, eps):
+    """Far from the crossover the ordering reverses, which is why 'auto' is mass.
+
+    The resistive step passes ``dt * eta`` here, which lives in this regime.
+    If this ever fails, the ``'laplacian'`` kind has become safe as a global
+    default and ``_coerce_diffusion_preconditioner_spec`` should be revisited.
+    """
+    seq, ops = seq_ops
+    mass_iters, mass_ok = solve_iters(seq, ops, rhs, eps, 'auto')
+    lap_iters, _ = solve_iters(seq, ops, rhs, eps, 'laplacian')
+    assert mass_ok, f"the mass atom must converge at eps={eps:g}"
+    assert mass_iters < lap_iters, (
+        f"at eps={eps:g} the mass atom took {mass_iters} iterations and the "
+        f"laplacian kind {lap_iters}; 'auto' resolves to mass on the strength "
+        "of this ordering")
+
+
+def test_the_smoothing_solve_is_not_quietly_expensive(seq_ops, rhs):
+    """A ceiling on the production configuration, loose enough to be believed.
+
+    The point is not the exact count but that it cannot silently grow by an
+    order of magnitude again. Measured 1655; the ceiling is 3x that, which
+    still catches a regression to the mass atom's 2130 becoming 8000.
+    """
+    seq, ops = seq_ops
+    iters, ok = solve_iters(seq, ops, rhs, 0.064 / NS[0] ** 2, 'laplacian')
+    assert ok, f"the production smoothing solve did not converge ({iters} iters)"
+    assert iters < 5000, (
+        f"the smoothing solve took {iters} iterations, measured 1655 when the "
+        "laplacian kind landed; something has regressed in the preconditioner")
+
+
+def test_unknown_kind_is_rejected(seq_ops, rhs):
+    """The kind list is the contract; a typo must not fall back to something."""
+    seq, ops = seq_ops
+    with pytest.raises(ValueError, match="preconditioner kind must be one of"):
+        apply_inverse_mass_plus_eps_laplace_matrix(
+            seq, ops, rhs, K, 1e-3, dirichlet=True,
+            preconditioner='laplacean', maxiter=1)


### PR DESCRIPTION
The velocity-smoothing solve `(M_2 + eps L_2) x = M_2 u` is **75% of a
relaxation step** ([#18](https://github.com/ToBlick/mrx/issues/18)). It was
preconditioned by the mass atom on the strength of this comment:

```
# M + eps L is MASS-DOMINATED in the regime this solve is used in
# (the relaxation's velocity smoothing: eps * lambda_max(M^-1 L) ~ 0.26
# at ns=(8,16,8)), so the production MASS preconditioner is the right object.
```

## That number is wrong by 350x, and it is not resolution-flat

Power iteration on `M^-1 L_hodge` (the operator the saddle system reduces to,
so including the `d d^T` half that `apply_stiffness` alone omits), li383, p=3,
float64:

| ns | eps | λ_max(M⁻¹L) | eps·λ_max | claimed |
|---|---|---|---|---|
| (8,16,8) | 1.000e-03 | 9.153e+04 | **91.5** | ~0.26 |
| (12,24,12) | 4.444e-04 | 8.107e+05 | **360.3** | ~0.26 |

The argument for flatness was that `eps ~ n_r^-2` cancels `lambda_max ~ n_r^2`.
It does not: λ_max grows 8.9x across those two while eps falls only 2.25x, so
**refining moves further from mass dominance**. The mass atom was
preconditioning the subdominant term, by two orders of magnitude.

MINRES converges steadily throughout, with no plateau, so this is an
ill-conditioned system being solved honestly rather than a solver failing.

## The fix

A `'laplacian'` kind, `(1/eps) P_L`, using the metric-lumped Laplacian atom
already on the bundle. `TimeStepper.smooth_velocity` asks for it; it could not
pass a preconditioner at all before. MINRES iterations to `sqrt_eps`, lower is
better:

| eps | mass (`'auto'`) | `'laplacian'` |
|---|---|---|
| 1e-06 | **498** | 3682 |
| 1e-04 | **750** | 2919 |
| 1e-03 — the smoothing eps at n_r=8 | 2130 | **1655** |
| 1e-02 | 5774 | **950** |

At (12,24,12), eps=4.44e-04: **8493 → 3636**.

The scaling improves as well as the level: mass goes 2130 → 8493 across those
resolutions (4.0x), the new kind 1655 → 3636 (2.2x).

`'auto'` stays mass. Below the crossover near eps=1e-4 mass is much better, and
that is where the resistive step's `dt * eta` lives.

End to end, one relaxation step at li383 (12,24,12) p=3 float32 goes **13.02 s
to 8.05 s, a 1.62x**, timed against the old preconditioner on the same machine
(a Cloud TPU v5e, using the harness in
[#17](https://github.com/ToBlick/mrx/pull/17); the iteration counts are
backend-independent, so a CPU or GPU sees the same ratio on a cheaper apply).

## Three alternatives, measured and rejected

| candidate | (8,16,8) | (12,24,12) |
|---|---|---|
| `'jacobi'`, the shifted diagonal that *does* know about eps·L | 14372 | no convergence in 20000 |
| unpreconditioned | no convergence | no convergence |
| preconditioned CG on the reduced SPD operator | 195 outer + 21708 inner | 462 outer + 54264 inner |

Reduced CG is the interesting one: it cuts outer iterations 18x, and then pays
every bit of it back in the inner mass solve needed to apply `d d^T`, landing
at wall-clock parity (53.4s vs 51.1s at (12,24,12)). Worth recording that an
inexact inner solve costs only 3% more outer iterations, so flexible CG is not
the obstacle — the inner solve simply is not cheap. A first-order Neumann
correction `P_M - eps P_M L P_M` produces NaN, as expected: it is SPD only for
`eps‖P_M L P_M‖ < 1`, which at these numbers it is not.

## Correctness

The relaxation trajectory is unchanged. Six li383 steps at (8,16,8), identical
but for the preconditioner, agree to **4.3e-09** relative in `B` and 2.8e-09 in
`||F||`, against a solver tolerance of 1.49e-08.

`test/test_diffusion_preconditioner.py` pins the *ordering* on both sides of
the crossover rather than an absolute count, which would be rewritten rather
than believed. No test pinned this anywhere, which is how a comment wrong by
350x survived.

## Follow-up, not done here

The principled object is a separable `(M + eps L)` atom, which would be right
at every eps and remove the crossover entirely — `docs/research/OPEN.md` §3.9
already proposes it for the sibling resistive solve, and the k=0
fast-diagonalisation path (`_fd_apply_3d(..., eps)`) shows the shape of it.
This PR is the cheap version that uses an atom already on the bundle, and
updates §3.9 to record which half of it is now measured and which still needs
the atom.

Made with [Cursor](https://cursor.com)
